### PR TITLE
Address Rob's comments for simplifying the model.

### DIFF
--- a/draft-ietf-bfd-unsolicited-15.xml
+++ b/draft-ietf-bfd-unsolicited-15.xml
@@ -282,7 +282,7 @@
             <section title="Unsolicited BFD Hierarchy">
             <t>Configuration for unsolicited BFD parameters for IP single-hop sessions can be done at 2 levels:
             <list style="symbols">
-            <t>Globally, i.e. for all interfaces. This requires support for the "unsolicited-params-global" feature.</t>
+            <t>Globally, i.e. for all interfaces.</t>
             <t>For specific interfaces. This requires support for the "unsolicited-params-per-interface" feature.</t>
             </list>
             If configuration exists at both levels, per-interface configuration takes precedence over global configuration.
@@ -297,8 +297,7 @@ module: ietf-bfd-unsolicited
 
   augment /rt:routing/rt:control-plane-protocols
           /rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh:
-    +--rw unsolicited {bfd-unsol:unsolicited-params-global}?
-       +--rw enabled?                          boolean
+    +--rw unsolicited?
        +--rw local-multiplier?                 multiplier
        +--rw (interval-config-type)?
           +--:(tx-rx-intervals)
@@ -309,10 +308,10 @@ module: ietf-bfd-unsolicited
   augment /rt:routing/rt:control-plane-protocols
           /rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh
           /bfd-ip-sh:interfaces:
-    +--rw unsolicited {bfd-unsol:unsolicited-params-per-interface}?
+    +--rw unsolicited
        +--rw enabled?                          boolean
-       +--rw local-multiplier?                 bfd-types:multiplier
-       +--rw (interval-config-type)?
+       +--rw local-multiplier?                 bfd-types:multiplier {bfd-unsol:unsolicited-params-per-interface}?
+       +--rw (interval-config-type)? {bfd-unsol:unsolicited-params-per-interface}?
           +--:(tx-rx-intervals)
           |  +--rw desired-min-tx-interval?    uint32
           |  +--rw required-min-rx-interval?   uint32
@@ -332,7 +331,7 @@ module: ietf-bfd-unsolicited
 	  <preamble/>
 
           <artwork align="left"><![CDATA[
-<CODE BEGINS> file "ietf-bfd-unsolicited@2023-03-26.yang"
+<CODE BEGINS> file "ietf-bfd-unsolicited@2023-04-21.yang"
 module ietf-bfd-unsolicited {
 
   yang-version 1.1;
@@ -402,7 +401,7 @@ module ietf-bfd-unsolicited {
 
   reference "RFC YYYY";
 
-  revision 2023-03-26 {
+  revision 2023-04-21 {
     description
       "Initial revision.";
     reference
@@ -412,14 +411,6 @@ module ietf-bfd-unsolicited {
   /*
    * Feature definitions
    */
-  feature unsolicited-params-global {
-    description
-      "This feature indicates that the server supports global
-       parameters for unsolicited sessions.";
-    reference
-      "RFC YYYY: Unsolicited BFD for Sessionless Applications.";
-  }
-
   feature unsolicited-params-per-interface {
     description
       "This feature indicates that the server supports per-interface
@@ -452,18 +443,11 @@ module ietf-bfd-unsolicited {
    */
    augment "/rt:routing/rt:control-plane-protocols/"
          + "rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh" {
-     if-feature bfd-unsol:unsolicited-params-global;
      description
        "Augmentation for BFD unsolicited parameters";
      container unsolicited {
        description
          "BFD IP single-hop unsolicited top level container";
-       leaf enabled {
-         type boolean;
-         default false;
-         description
-           "BFD unsolicited enabled globally for IP single-hop.";
-       }
        uses bfd-types:base-cfg-parms;
      }
    }
@@ -471,23 +455,9 @@ module ietf-bfd-unsolicited {
    augment "/rt:routing/rt:control-plane-protocols/"
          + "rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh/"
          + "bfd-ip-sh:interfaces" {
-     if-feature bfd-unsol:unsolicited-params-per-interface;
      description
        "Augmentation for BFD unsolicited on IP single-hop interface";
      container unsolicited {
-       must "local-multiplier or ../../unsolicited/local-multiplier" {
-         error-message
-           "The local-multiplier must be specified either under the interface
-            or globally.";
-       }
-       must "(min-interval or ../../unsolicited/min-interval) or
-             (desired-min-tx-interval and required-min-rx-interval) or
-             (../../unsolicited/desired-min-tx-interval and
-              ../../unsolicited/required-min-rx-interval)" {
-         error-message
-           "The interval(s) must be specified either under the interface
-            or globally.";
-       }
        description
          "BFD IP single-hop interface unsolicited top level 
           container";
@@ -502,16 +472,22 @@ module ietf-bfd-unsolicited {
         * without default values (for inheritance)
         */
        leaf local-multiplier {
+         if-feature bfd-unsol:unsolicited-params-per-interface;
          type bfd-types:multiplier;
          description
            "Multiplier transmitted by the local system. Defaults to
-            ../../unsolicited/local-multiplier.";
+            ../../unsolicited/local-multiplier.
+            A multiplier configured under an interface takes precedence
+            over the mulitiplier configured at the global level.";
        }
 
        choice interval-config-type {
+         if-feature bfd-unsol:unsolicited-params-per-interface;
          description
            "Two interval values or one value used for both transmit and
-            receive. Defaults to ../../unsolicited/interval-config-type.";
+            receive. Defaults to ../../unsolicited/interval-config-type.
+            An interval configured under an interface takes precedence
+            over any interval configured at the global level.";
          case tx-rx-intervals {
            leaf desired-min-tx-interval {
              type uint32;
@@ -592,7 +568,6 @@ module ietf-bfd-unsolicited {
       <bfd xmlns="urn:ietf:params:xml:ns:yang:ietf-bfd">
         <ip-sh xmlns="urn:ietf:params:xml:ns:yang:ietf-bfd-ip-sh">
           <unsolicited>
-            <enabled>true</enabled>
             <local-multiplier>2</local-multiplier>
             <min-interval>50000</min-interval>
           </unsolicited>

--- a/draft-ietf-bfd-unsolicited-15.xml
+++ b/draft-ietf-bfd-unsolicited-15.xml
@@ -622,9 +622,9 @@ module ietf-bfd-unsolicited {
 
 	<section title="Acknowledgments"> 
 
-	<t>Authors would like to thank Acee Lindem, Greg Mirsky, Jeffrey Haas, 
-      Raj Chetan, Tom Petch, Henning Rogge, Mahesh Jethanandani, Gyan Mishra, John Scudder
-      and Dan Romascanu for their review and valuable input.</t>
+	<t>Authors would like to thank Acee Lindem, Alvaro Retana, Dan Romascanu, Derek Atkins, Greg Mirsky, Gyan Mishra, Henning Rogge, Jeffrey Haas,
+      John Scudder, Lars Eggert, Magnus Westerlund, Mahesh Jethanandani, Murray Kucherawy, Raj Chetan, Robert Wilton, Roman Danyliw, Tom Petch,
+      and Zaheduzzaman Sarker for their review and valuable input.</t>
 
 	</section> 
 

--- a/draft-ietf-bfd-unsolicited-15.xml
+++ b/draft-ietf-bfd-unsolicited-15.xml
@@ -331,7 +331,7 @@ module: ietf-bfd-unsolicited
 	  <preamble/>
 
           <artwork align="left"><![CDATA[
-<CODE BEGINS> file "ietf-bfd-unsolicited@2023-04-21.yang"
+<CODE BEGINS> file "ietf-bfd-unsolicited@2023-04-22.yang"
 module ietf-bfd-unsolicited {
 
   yang-version 1.1;
@@ -401,7 +401,7 @@ module ietf-bfd-unsolicited {
 
   reference "RFC YYYY";
 
-  revision 2023-04-21 {
+  revision 2023-04-22 {
     description
       "Initial revision.";
     reference
@@ -422,18 +422,22 @@ module ietf-bfd-unsolicited {
   /*
    * Type Definitions
    */
-  typedef role {
-    type enumeration {
-      enum active {
-        description "Active role";
-      }
-      enum passive {
-        description "Passive role";
-      }
-    }
+  identity role {
     description
-      "Role of local system during BFD session initialization.";
-    reference 
+      "Base identity from which all roles are derived.
+       Role of local system during BFD session initialization.";
+  }
+  identity active {
+    base "bfd-unsol:role";
+    description "Active role";
+    reference
+      "RFC5880: Bidirectional Forwarding Detection (BFD),
+       Section 6.1";
+  }
+  identity passive {
+    base "bfd-unsol:role";
+    description "Passive role";
+    reference
       "RFC5880: Bidirectional Forwarding Detection (BFD),
        Section 6.1";
   }
@@ -522,7 +526,9 @@ module ietf-bfd-unsolicited {
     description
       "Augmentation for BFD unsolicited on IP single-hop session";
       leaf role {
-        type bfd-unsol:role;
+        type identityref {
+          base "bfd-unsol:role";
+        }
         config false;
         description "Role.";
       }

--- a/ietf-bfd-unsolicited.yang
+++ b/ietf-bfd-unsolicited.yang
@@ -67,7 +67,7 @@ module ietf-bfd-unsolicited {
 
   reference "RFC YYYY";
 
-  revision 2023-04-21 {
+  revision 2023-04-22 {
     description
       "Initial revision.";
     reference
@@ -88,18 +88,22 @@ module ietf-bfd-unsolicited {
   /*
    * Type Definitions
    */
-  typedef role {
-    type enumeration {
-      enum active {
-        description "Active role";
-      }
-      enum passive {
-        description "Passive role";
-      }
-    }
+  identity role {
     description
-      "Role of local system during BFD session initialization.";
-    reference 
+      "Base identity from which all roles are derived.
+       Role of local system during BFD session initialization.";
+  }
+  identity active {
+    base "bfd-unsol:role";
+    description "Active role";
+    reference
+      "RFC5880: Bidirectional Forwarding Detection (BFD),
+       Section 6.1";
+  }
+  identity passive {
+    base "bfd-unsol:role";
+    description "Passive role";
+    reference
       "RFC5880: Bidirectional Forwarding Detection (BFD),
        Section 6.1";
   }
@@ -188,7 +192,9 @@ module ietf-bfd-unsolicited {
     description
       "Augmentation for BFD unsolicited on IP single-hop session";
       leaf role {
-        type bfd-unsol:role;
+        type identityref {
+          base "bfd-unsol:role";
+        }
         config false;
         description "Role.";
       }

--- a/ietf-bfd-unsolicited.yang
+++ b/ietf-bfd-unsolicited.yang
@@ -67,7 +67,7 @@ module ietf-bfd-unsolicited {
 
   reference "RFC YYYY";
 
-  revision 2023-03-26 {
+  revision 2023-04-21 {
     description
       "Initial revision.";
     reference
@@ -77,14 +77,6 @@ module ietf-bfd-unsolicited {
   /*
    * Feature definitions
    */
-  feature unsolicited-params-global {
-    description
-      "This feature indicates that the server supports global
-       parameters for unsolicited sessions.";
-    reference
-      "RFC YYYY: Unsolicited BFD for Sessionless Applications.";
-  }
-
   feature unsolicited-params-per-interface {
     description
       "This feature indicates that the server supports per-interface
@@ -117,18 +109,11 @@ module ietf-bfd-unsolicited {
    */
    augment "/rt:routing/rt:control-plane-protocols/"
          + "rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh" {
-     if-feature bfd-unsol:unsolicited-params-global;
      description
        "Augmentation for BFD unsolicited parameters";
      container unsolicited {
        description
          "BFD IP single-hop unsolicited top level container";
-       leaf enabled {
-         type boolean;
-         default false;
-         description
-           "BFD unsolicited enabled globally for IP single-hop.";
-       }
        uses bfd-types:base-cfg-parms;
      }
    }
@@ -136,23 +121,9 @@ module ietf-bfd-unsolicited {
    augment "/rt:routing/rt:control-plane-protocols/"
          + "rt:control-plane-protocol/bfd:bfd/bfd-ip-sh:ip-sh/"
          + "bfd-ip-sh:interfaces" {
-     if-feature bfd-unsol:unsolicited-params-per-interface;
      description
        "Augmentation for BFD unsolicited on IP single-hop interface";
      container unsolicited {
-       must "local-multiplier or ../../unsolicited/local-multiplier" {
-         error-message
-           "The local-multiplier must be specified either under the interface
-            or globally.";
-       }
-       must "(min-interval or ../../unsolicited/min-interval) or
-             (desired-min-tx-interval and required-min-rx-interval) or
-             (../../unsolicited/desired-min-tx-interval and
-              ../../unsolicited/required-min-rx-interval)" {
-         error-message
-           "The interval(s) must be specified either under the interface
-            or globally.";
-       }
        description
          "BFD IP single-hop interface unsolicited top level 
           container";
@@ -167,16 +138,22 @@ module ietf-bfd-unsolicited {
         * without default values (for inheritance)
         */
        leaf local-multiplier {
+         if-feature bfd-unsol:unsolicited-params-per-interface;
          type bfd-types:multiplier;
          description
            "Multiplier transmitted by the local system. Defaults to
-            ../../unsolicited/local-multiplier.";
+            ../../unsolicited/local-multiplier.
+            A multiplier configured under an interface takes precedence
+            over the mulitiplier configured at the global level.";
        }
 
        choice interval-config-type {
+         if-feature bfd-unsol:unsolicited-params-per-interface;
          description
            "Two interval values or one value used for both transmit and
-            receive. Defaults to ../../unsolicited/interval-config-type.";
+            receive. Defaults to ../../unsolicited/interval-config-type.
+            An interval configured under an interface takes precedence
+            over any interval configured at the global level.";
          case tx-rx-intervals {
            leaf desired-min-tx-interval {
              type uint32;


### PR DESCRIPTION
Removed feature for global config. Removed enable global leaf since it doesn't make sense to enable unsolicited BFD globally, i.e. on all interfaces.

Per-interface config, use the feature for the params only (interval/multiplier), enabled does not depend on the feature.

Since global config isn't feature dependent anymore, removed the must statements.

Updated description for session parms under interface.

Changed role from enum to identity as suggested by Jeff.

Updated acknowledgement section.